### PR TITLE
Split site into multi-page layout with inline scripts for WordPress blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+__pycache__/

--- a/about.html
+++ b/about.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>About — S&S Kreates Co.</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com"/>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+  <link href="https://fonts.googleapis.com/css2?family=Lobster+Two:wght@400;700&family=Playfair+Display:wght@400;500;700&display=swap" rel="stylesheet"/>
+  <link rel="stylesheet" href="css/style.css"/>
+</head>
+<body>
+  <header>
+    <div class="container top">
+      <a class="brand" href="index.html">
+        <span class="brand-logo" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M20 9c0-3.3-3.1-6-7-6-3.4 0-6.3 1.9-6.9 4.6C4.1 7.6 3 8.4 3 9.5c0 1 .9 1.9 2 1.9h.3c.6 2.7 3.5 4.6 6.9 4.6 1.6 0 3.1-.4 4.3-1.1l1.8 1.1c.5.3 1.2.1 1.5-.4.3-.5.1-1.2-.4-1.5l-1.2-.7c.9-1.1 1.5-2.5 1.5-4.1Z" fill="%23B399D4"/><circle cx="13.5" cy="6.5" r=".8" fill="#2f2a37"/></svg>
+        </span>
+        <span>S&S Kreates Co.</span>
+      </a>
+      <nav>
+        <a class="nav-btn" href="shop.html">Shop</a>
+        <a class="nav-btn" href="challenges.html">Challenges</a>
+        <a class="nav-btn" href="lookbook.html">Lookbook</a>
+        <a class="nav-btn" href="about.html">About</a>
+        <a class="nav-btn" href="contact.html">Contact</a>
+        <a class="nav-btn" href="account.html" data-login>My Account <span class="cart-badge" aria-label="items in cart">3</span></a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="container">
+    <section aria-labelledby="about-title">
+      <h2 id="about-title">Designed by Rose, With Love</h2>
+      <div class="grid cols-3">
+        <div class="card" style="grid-column:span 2">
+          <p>Every product is personally designed by Rose — CEO, artist and one‑woman studio. We blend whimsical visuals with practical tools so saving feels joyful, not restrictive.</p>
+          <p>Our signature: pastel purples, teal accents, butterflies and coins. The result is a calm, motivating space to grow your savings.</p>
+        </div>
+        <div class="card"><strong>Portland → Worldwide</strong><p class="muted">Digital goods ship instantly. Physical sets ship weekly.</p></div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container">© <span id="year"></span> S&S Kreates Co. • Budget, Save & Play</div>
+  </footer>
+
+  <dialog id="loginModal" class="modal">
+    <button type="button" id="closeLogin" class="modal-close" aria-label="Close">×</button>
+    <div id="loginView">
+      <h2>Log In</h2>
+      <form class="modal-form">
+        <label>Email
+          <input type="email" required />
+        </label>
+        <label>Password
+          <input type="password" required />
+        </label>
+        <button type="submit" class="btn primary">Log In</button>
+      </form>
+    </div>
+    <div id="signupView" hidden>
+      <h2>Sign Up</h2>
+      <form class="modal-form">
+        <label>Email
+          <input type="email" required />
+        </label>
+        <label>Password
+          <input type="password" required />
+        </label>
+        <button type="submit" class="btn primary">Create Account</button>
+      </form>
+    </div>
+    <button type="button" class="modal-switch" id="switchAuth">Need an account? Sign up</button>
+  </dialog>
+
+  <script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const year = document.getElementById('year');
+    if (year) year.textContent = new Date().getFullYear();
+
+    const modal = document.getElementById('loginModal');
+    const loginLinks = document.querySelectorAll('[data-login]');
+    const closeBtn = document.getElementById('closeLogin');
+    const switchAuth = document.getElementById('switchAuth');
+    const loginView = document.getElementById('loginView');
+    const signupView = document.getElementById('signupView');
+
+    loginLinks.forEach(link => {
+      link.addEventListener('click', e => {
+        e.preventDefault();
+        modal.showModal();
+      });
+    });
+    if (closeBtn) closeBtn.addEventListener('click', () => modal.close());
+    if (switchAuth) {
+      switchAuth.addEventListener('click', () => {
+        const showSignup = signupView.hasAttribute('hidden');
+        signupView.toggleAttribute('hidden');
+        loginView.toggleAttribute('hidden');
+        switchAuth.textContent = showSignup ? 'Have an account? Log in' : 'Need an account? Sign up';
+      });
+    }
+  });
+  </script>
+</body>
+</html>

--- a/account.html
+++ b/account.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Account — S&S Kreates Co.</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com"/>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+  <link href="https://fonts.googleapis.com/css2?family=Lobster+Two:wght@400;700&family=Playfair+Display:wght@400;500;700&display=swap" rel="stylesheet"/>
+  <link rel="stylesheet" href="css/style.css"/>
+</head>
+<body>
+  <header>
+    <div class="container top">
+      <a class="brand" href="index.html">
+        <span class="brand-logo" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M20 9c0-3.3-3.1-6-7-6-3.4 0-6.3 1.9-6.9 4.6C4.1 7.6 3 8.4 3 9.5c0 1 .9 1.9 2 1.9h.3c.6 2.7 3.5 4.6 6.9 4.6 1.6 0 3.1-.4 4.3-1.1l1.8 1.1c.5.3 1.2.1 1.5-.4.3-.5.1-1.2-.4-1.5l-1.2-.7c.9-1.1 1.5-2.5 1.5-4.1Z" fill="%23B399D4"/><circle cx="13.5" cy="6.5" r=".8" fill="#2f2a37"/></svg>
+        </span>
+        <span>S&S Kreates Co.</span>
+      </a>
+      <nav>
+        <a class="nav-btn" href="shop.html">Shop</a>
+        <a class="nav-btn" href="challenges.html">Challenges</a>
+        <a class="nav-btn" href="lookbook.html">Lookbook</a>
+        <a class="nav-btn" href="about.html">About</a>
+        <a class="nav-btn" href="contact.html">Contact</a>
+        <a class="nav-btn" href="account.html" data-login>My Account <span class="cart-badge" aria-label="items in cart">3</span></a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="container">
+    <section aria-labelledby="acct-title">
+      <h2 id="acct-title">My Account</h2>
+      <div class="wc"><code>[woocommerce_my_account]</code></div>
+      <div class="wc" style="margin-top:12px"><code>[woocommerce_cart]</code> · <code>[woocommerce_checkout]</code></div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container">© <span id="year"></span> S&S Kreates Co. • Budget, Save & Play</div>
+  </footer>
+
+  <dialog id="loginModal" class="modal">
+    <button type="button" id="closeLogin" class="modal-close" aria-label="Close">×</button>
+    <div id="loginView">
+      <h2>Log In</h2>
+      <form class="modal-form">
+        <label>Email
+          <input type="email" required />
+        </label>
+        <label>Password
+          <input type="password" required />
+        </label>
+        <button type="submit" class="btn primary">Log In</button>
+      </form>
+    </div>
+    <div id="signupView" hidden>
+      <h2>Sign Up</h2>
+      <form class="modal-form">
+        <label>Email
+          <input type="email" required />
+        </label>
+        <label>Password
+          <input type="password" required />
+        </label>
+        <button type="submit" class="btn primary">Create Account</button>
+      </form>
+    </div>
+    <button type="button" class="modal-switch" id="switchAuth">Need an account? Sign up</button>
+  </dialog>
+
+  <script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const year = document.getElementById('year');
+    if (year) year.textContent = new Date().getFullYear();
+
+    const modal = document.getElementById('loginModal');
+    const loginLinks = document.querySelectorAll('[data-login]');
+    const closeBtn = document.getElementById('closeLogin');
+    const switchAuth = document.getElementById('switchAuth');
+    const loginView = document.getElementById('loginView');
+    const signupView = document.getElementById('signupView');
+
+    loginLinks.forEach(link => {
+      link.addEventListener('click', e => {
+        e.preventDefault();
+        modal.showModal();
+      });
+    });
+    if (closeBtn) closeBtn.addEventListener('click', () => modal.close());
+    if (switchAuth) {
+      switchAuth.addEventListener('click', () => {
+        const showSignup = signupView.hasAttribute('hidden');
+        signupView.toggleAttribute('hidden');
+        loginView.toggleAttribute('hidden');
+        switchAuth.textContent = showSignup ? 'Have an account? Log in' : 'Need an account? Sign up';
+      });
+    }
+  });
+  </script>
+</body>
+</html>

--- a/challenges.html
+++ b/challenges.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Challenges — S&S Kreates Co.</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com"/>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+  <link href="https://fonts.googleapis.com/css2?family=Lobster+Two:wght@400;700&family=Playfair+Display:wght@400;500;700&display=swap" rel="stylesheet"/>
+  <link rel="stylesheet" href="css/style.css"/>
+</head>
+<body>
+  <header>
+    <div class="container top">
+      <a class="brand" href="index.html">
+        <span class="brand-logo" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M20 9c0-3.3-3.1-6-7-6-3.4 0-6.3 1.9-6.9 4.6C4.1 7.6 3 8.4 3 9.5c0 1 .9 1.9 2 1.9h.3c.6 2.7 3.5 4.6 6.9 4.6 1.6 0 3.1-.4 4.3-1.1l1.8 1.1c.5.3 1.2.1 1.5-.4.3-.5.1-1.2-.4-1.5l-1.2-.7c.9-1.1 1.5-2.5 1.5-4.1Z" fill="%23B399D4"/><circle cx="13.5" cy="6.5" r=".8" fill="#2f2a37"/></svg>
+        </span>
+        <span>S&S Kreates Co.</span>
+      </a>
+      <nav>
+        <a class="nav-btn" href="shop.html">Shop</a>
+        <a class="nav-btn" href="challenges.html">Challenges</a>
+        <a class="nav-btn" href="lookbook.html">Lookbook</a>
+        <a class="nav-btn" href="about.html">About</a>
+        <a class="nav-btn" href="contact.html">Contact</a>
+        <a class="nav-btn" href="account.html" data-login>My Account <span class="cart-badge" aria-label="items in cart">3</span></a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="container">
+    <section aria-labelledby="ch-title">
+      <h2 id="ch-title">Savings Challenges</h2>
+      <div class="wc"><code>[product_categories parent="savings-challenges" columns="3"]</code></div>
+      <div class="grid cols-3" style="margin-top:16px">
+        <div class="card"><h3>No‑Spend Weekend</h3><p class="muted">Small wins, big vibes</p></div>
+        <div class="card"><h3>Loose‑Change Ladder</h3><p class="muted">Turn coins into goals</p></div>
+        <div class="card"><h3>Cash‑Stuffing Sprint</h3><p class="muted">Weekly envelopes</p></div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container">© <span id="year"></span> S&S Kreates Co. • Budget, Save & Play</div>
+  </footer>
+
+  <dialog id="loginModal" class="modal">
+    <button type="button" id="closeLogin" class="modal-close" aria-label="Close">×</button>
+    <div id="loginView">
+      <h2>Log In</h2>
+      <form class="modal-form">
+        <label>Email
+          <input type="email" required />
+        </label>
+        <label>Password
+          <input type="password" required />
+        </label>
+        <button type="submit" class="btn primary">Log In</button>
+      </form>
+    </div>
+    <div id="signupView" hidden>
+      <h2>Sign Up</h2>
+      <form class="modal-form">
+        <label>Email
+          <input type="email" required />
+        </label>
+        <label>Password
+          <input type="password" required />
+        </label>
+        <button type="submit" class="btn primary">Create Account</button>
+      </form>
+    </div>
+    <button type="button" class="modal-switch" id="switchAuth">Need an account? Sign up</button>
+  </dialog>
+
+  <script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const year = document.getElementById('year');
+    if (year) year.textContent = new Date().getFullYear();
+
+    const modal = document.getElementById('loginModal');
+    const loginLinks = document.querySelectorAll('[data-login]');
+    const closeBtn = document.getElementById('closeLogin');
+    const switchAuth = document.getElementById('switchAuth');
+    const loginView = document.getElementById('loginView');
+    const signupView = document.getElementById('signupView');
+
+    loginLinks.forEach(link => {
+      link.addEventListener('click', e => {
+        e.preventDefault();
+        modal.showModal();
+      });
+    });
+    if (closeBtn) closeBtn.addEventListener('click', () => modal.close());
+    if (switchAuth) {
+      switchAuth.addEventListener('click', () => {
+        const showSignup = signupView.hasAttribute('hidden');
+        signupView.toggleAttribute('hidden');
+        loginView.toggleAttribute('hidden');
+        switchAuth.textContent = showSignup ? 'Have an account? Log in' : 'Need an account? Sign up';
+      });
+    }
+  });
+  </script>
+</body>
+</html>

--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Contact — S&S Kreates Co.</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com"/>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+  <link href="https://fonts.googleapis.com/css2?family=Lobster+Two:wght@400;700&family=Playfair+Display:wght@400;500;700&display=swap" rel="stylesheet"/>
+  <link rel="stylesheet" href="css/style.css"/>
+</head>
+<body>
+  <header>
+    <div class="container top">
+      <a class="brand" href="index.html">
+        <span class="brand-logo" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M20 9c0-3.3-3.1-6-7-6-3.4 0-6.3 1.9-6.9 4.6C4.1 7.6 3 8.4 3 9.5c0 1 .9 1.9 2 1.9h.3c.6 2.7 3.5 4.6 6.9 4.6 1.6 0 3.1-.4 4.3-1.1l1.8 1.1c.5.3 1.2.1 1.5-.4.3-.5.1-1.2-.4-1.5l-1.2-.7c.9-1.1 1.5-2.5 1.5-4.1Z" fill="%23B399D4"/><circle cx="13.5" cy="6.5" r=".8" fill="#2f2a37"/></svg>
+        </span>
+        <span>S&S Kreates Co.</span>
+      </a>
+      <nav>
+        <a class="nav-btn" href="shop.html">Shop</a>
+        <a class="nav-btn" href="challenges.html">Challenges</a>
+        <a class="nav-btn" href="lookbook.html">Lookbook</a>
+        <a class="nav-btn" href="about.html">About</a>
+        <a class="nav-btn" href="contact.html">Contact</a>
+        <a class="nav-btn" href="account.html" data-login>My Account <span class="cart-badge" aria-label="items in cart">3</span></a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="container">
+    <section aria-labelledby="contact-title">
+      <h2 id="contact-title">Contact</h2>
+      <div class="grid cols-3">
+        <div class="card"><h3>Email</h3><p>hello@sskreates.com</p></div>
+        <div class="card"><h3>Instagram</h3><p>@sskreates.co</p></div>
+        <div class="card"><h3>Support</h3><p class="muted">Weekdays 9–5 ET</p></div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container">© <span id="year"></span> S&S Kreates Co. • Budget, Save & Play</div>
+  </footer>
+
+  <dialog id="loginModal" class="modal">
+    <button type="button" id="closeLogin" class="modal-close" aria-label="Close">×</button>
+    <div id="loginView">
+      <h2>Log In</h2>
+      <form class="modal-form">
+        <label>Email
+          <input type="email" required />
+        </label>
+        <label>Password
+          <input type="password" required />
+        </label>
+        <button type="submit" class="btn primary">Log In</button>
+      </form>
+    </div>
+    <div id="signupView" hidden>
+      <h2>Sign Up</h2>
+      <form class="modal-form">
+        <label>Email
+          <input type="email" required />
+        </label>
+        <label>Password
+          <input type="password" required />
+        </label>
+        <button type="submit" class="btn primary">Create Account</button>
+      </form>
+    </div>
+    <button type="button" class="modal-switch" id="switchAuth">Need an account? Sign up</button>
+  </dialog>
+
+  <script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const year = document.getElementById('year');
+    if (year) year.textContent = new Date().getFullYear();
+
+    const modal = document.getElementById('loginModal');
+    const loginLinks = document.querySelectorAll('[data-login]');
+    const closeBtn = document.getElementById('closeLogin');
+    const switchAuth = document.getElementById('switchAuth');
+    const loginView = document.getElementById('loginView');
+    const signupView = document.getElementById('signupView');
+
+    loginLinks.forEach(link => {
+      link.addEventListener('click', e => {
+        e.preventDefault();
+        modal.showModal();
+      });
+    });
+    if (closeBtn) closeBtn.addEventListener('click', () => modal.close());
+    if (switchAuth) {
+      switchAuth.addEventListener('click', () => {
+        const showSignup = signupView.hasAttribute('hidden');
+        signupView.toggleAttribute('hidden');
+        loginView.toggleAttribute('hidden');
+        switchAuth.textContent = showSignup ? 'Have an account? Log in' : 'Need an account? Sign up';
+      });
+    }
+  });
+  </script>
+</body>
+</html>

--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,103 @@
+:root{
+  --primary:#B399D4;
+  --secondary:#77D4D1;
+  --ink:#2f2a37;
+  --muted:#6e6578;
+  --bg:#FBFAFD;
+  --card:#ffffff;
+  --border:#eadff7;
+  --radius:16px;
+  --shadow:0 8px 30px rgba(46, 6, 85, .08);
+}
+*{box-sizing:border-box}
+html,body{height:100%}
+body{margin:0;background:var(--bg);color:var(--ink);font-family:'Playfair Display',serif;line-height:1.55;-webkit-font-smoothing:antialiased}
+h1,h2,h3,h4{font-family:'Lobster Two',cursive;margin:0 0 .4em 0;color:var(--ink);letter-spacing:.2px}
+h1{font-size:clamp(2rem,4.8vw,3.2rem)}
+h2{font-size:clamp(1.6rem,3.6vw,2.2rem)}
+p{margin:.2em 0 1em 0}
+a{color:inherit;text-decoration:none}
+button{font-family:inherit}
+
+/* Layout */
+.container{max-width:1180px;margin:0 auto;padding:0 20px}
+header{position:sticky;top:0;z-index:20;background:rgba(255,255,255,.75);backdrop-filter:saturate(160%) blur(8px);border-bottom:1px solid var(--border)}
+.top{display:flex;align-items:center;justify-content:space-between;padding:14px 0}
+.brand{display:flex;align-items:center;gap:10px;font-weight:700}
+.brand-logo{width:36px;height:36px;border-radius:50%;display:grid;place-items:center;background:#fff;border:2px solid var(--primary);box-shadow:0 2px 8px rgba(179,153,212,.35)}
+.brand-logo svg{width:22px;height:22px}
+nav{display:flex;gap:10px;flex-wrap:wrap}
+.nav-btn{display:inline-flex;gap:8px;align-items:center;padding:8px 12px;border-radius:999px}
+.nav-btn:hover{background:#f3eefb}
+.cart-badge{margin-left:6px;min-width:18px;height:18px;border-radius:999px;background:var(--primary);color:#fff;font-weight:700;font-size:12px;display:grid;place-items:center}
+
+/* Hero */
+.hero{position:relative;margin:18px 0}
+.hero-inner{border:1px solid var(--border);background:var(--card);border-radius:24px;overflow:hidden;box-shadow:var(--shadow)}
+.hero-art{position:relative;height:420px}
+.hero-art::before{content:"";position:absolute;inset:0;background:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1600' height='900' viewBox='0 0 1600 900'%3E%3Cdefs%3E%3ClinearGradient id='g' x1='0' y1='0' x2='1' y2='1'%3E%3Cstop stop-color='%23B399D4' offset='0'/%3E%3Cstop stop-color='%2377D4D1' offset='1'/%3E%3C/linearGradient%3E%3C/defs%3E%3Crect fill='%23fbfafd' width='1600' height='900'/%3E%3Cpath d='M0,600 C300,520 400,700 800,560 C1200,420 1300,700 1600,540 L1600,900 L0,900 Z' fill='%23efe9fb'/%3E%3Ccircle cx='200' cy='160' r='90' fill='%23f6f3fd'/%3E%3Ccircle cx='1420' cy='120' r='70' fill='%23eefaf8'/%3E%3Cg opacity='.8'%3E%3Ctext x='240' y='130' font-size='44'%3E%F0%9F%A6%8B%3C/text%3E%3Ctext x='1340' y='170' font-size='40'%3E%F0%9F%AA%99%3C/text%3E%3Ctext x='360' y='260' font-size='38'%3E%F0%9F%AA%99%3C/text%3E%3Ctext x='1180' y='240' font-size='44'%3E%F0%9F%A6%8B%3C/text%3E%3C/g%3E%3C/svg%3E") center/cover no-repeat}
+.hero-copy{position:absolute;inset:auto 0 24px 24px;color:#1b1330;max-width:640px}
+.hero h1{text-shadow:0 4px 20px rgba(0,0,0,.20)}
+.lede{background:rgba(255,255,255,.85);display:inline-block;padding:10px 14px;border-radius:12px;border:1px solid var(--border)}
+.buttons{display:flex;gap:10px;flex-wrap:wrap;margin-top:12px}
+.btn{display:inline-flex;align-items:center;gap:8px;padding:10px 16px;border-radius:999px;border:2px solid var(--primary);background:#fff;color:#1b1330;font-weight:700;cursor:pointer;transition:.25s box-shadow,.25s transform}
+.btn.primary{background:linear-gradient(90deg,var(--primary),var(--secondary));color:#fff;border-color:transparent}
+.btn:hover{transform:translateY(-2px);box-shadow:0 10px 22px rgba(179,153,212,.25)}
+
+/* Floating coins/butterflies */
+.float{pointer-events:none;position:absolute;inset:0;overflow:hidden}
+.float span{position:absolute;top:-10%;font-size:22px;animation:fall var(--speed,10s) linear infinite;opacity:.85}
+.float span:nth-child(odd){filter:drop-shadow(0 4px 10px rgba(179,153,212,.35))}
+@keyframes fall{0%{transform:translateY(-10%) rotate(0)}100%{transform:translateY(120vh) rotate(360deg)}}
+
+/* Sections */
+main{margin:26px 0 60px}
+
+/* Cards & grids */
+.grid{display:grid;gap:16px}
+@media(min-width:760px){
+  .grid.cols-3{grid-template-columns:repeat(3,1fr)}
+  .grid.cols-4{grid-template-columns:repeat(4,1fr)}
+}
+.card{background:var(--card);border:1px solid var(--border);border-radius:var(--radius);box-shadow:var(--shadow);padding:16px}
+
+/* Category tiles */
+.cat{display:flex;flex-direction:column;align-items:center;justify-content:center;min-height:160px;text-align:center;background:linear-gradient(145deg,#f6f2fe,#eefaf8);border:1px solid var(--border);border-radius:16px;position:relative;overflow:hidden;transition:.25s transform,.25s box-shadow}
+.cat:hover{transform:translateY(-4px);box-shadow:0 12px 24px rgba(119,212,209,.22)}
+.cat .emoji{font-size:36px;margin-bottom:8px}
+
+/* Scratch demo */
+.scratch-wrap{display:grid;grid-template-columns:1.2fr 1fr;gap:18px;align-items:center}
+@media(max-width:900px){.scratch-wrap{grid-template-columns:1fr;}}
+.scratch-card{position:relative;aspect-ratio:5/3;border-radius:20px;background:linear-gradient(135deg,#f7f1ff,#f0fbf9);border:2px dashed var(--primary);box-shadow:var(--shadow);overflow:hidden}
+.scratch-art{position:absolute;inset:0;background:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1000 600'%3E%3Cdefs%3E%3ClinearGradient id='p' x1='0' y1='0' x2='1' y2='1'%3E%3Cstop offset='0' stop-color='%23B399D4'/%3E%3Cstop offset='1' stop color='%2377D4D1'/%3E%3C/linearGradient%3E%3C/defs%3E%3Crect width='1000' height='600' fill='%23f9f6ff'/%3E%3Ctext x='60' y='110' font-size='64' fill='%231b1330' font-family='Lobster Two' %3ES%26S Kreates Co.%3C/text%3E%3Ctext x='60' y='170' font-size='28' fill='%236e6578' font-family='Playfair Display' %3EDigital Savings Challenge%3C/text%3E%3Cg opacity='.22'%3E%3Ctext x='820' y='90' font-size='40'%3E%F0%9F%A6%8B%3C/text%3E%3Ctext x='120' y='510' font-size='44'%3E%F0%9F%AA%99%3C/text%3E%3Ctext x='920' y='560' font-size='38'%3E%F0%9F%AA%99%3C/text%3E%3C/g%3E%3C/svg%3E") center/cover no-repeat}
+.scratch-grid{position:absolute;inset:0;display:grid;grid-template-columns:repeat(6,1fr);grid-auto-rows:minmax(0,1fr);gap:8px;padding:22px;align-content:end}
+.circle{position:relative;border-radius:999px;background:rgba(179,153,212,.22);box-shadow:inset 0 2px 10px rgba(0,0,0,.06);display:grid;place-items:center;overflow:hidden}
+.circle .amt{z-index:1;font-weight:700;color:#1b1330;background:rgba(255,255,255,.85);padding:2px 8px;border-radius:10px;border:1px solid var(--border)}
+canvas.silver{position:absolute;inset:0}
+.spark{position:absolute;width:6px;height:6px;background:radial-gradient(circle,#fff,rgba(255,255,255,0));border-radius:999px;animation:pop .7s ease forwards}
+@keyframes pop{0%{transform:scale(.2);opacity:0}45%{transform:scale(1.6);opacity:.95}100%{transform:scale(.1);opacity:0}}
+.scratch-notes{font-size:15px;color:var(--muted)}
+
+/* Shop & shortcodes */
+.wc{padding:20px;background:var(--card);border:1px dashed var(--border);border-radius:12px}
+.wc code{background:#f3eefb;border:1px solid var(--border);padding:2px 6px;border-radius:6px}
+
+/* Footer */
+footer{border-top:1px solid var(--border);padding:28px 0;color:var(--muted)}
+
+/* Accessibility */
+:focus-visible{outline:3px solid var(--secondary);outline-offset:2px;border-radius:10px}
+@media (prefers-reduced-motion: reduce){
+  .btn,.cat{transition:none}
+  .float span,.spark{animation:none}
+}
+
+/* Login modal */
+dialog.modal{border:none;border-radius:var(--radius);padding:30px;max-width:400px;width:90%;}
+dialog::backdrop{background:rgba(0,0,0,.4);}
+.modal-close{position:absolute;top:10px;right:10px;background:none;border:none;font-size:20px;cursor:pointer}
+.modal-form{display:flex;flex-direction:column;gap:10px}
+.modal-form label{font-size:14px;display:flex;flex-direction:column}
+.modal-form input{padding:8px;border:1px solid var(--border);border-radius:8px}
+.modal-switch{background:none;border:none;color:var(--primary);cursor:pointer;font-size:14px;text-decoration:underline;margin-top:8px}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,214 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>S&S Kreates Co. — Budget, Save & Play</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com"/>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+  <link href="https://fonts.googleapis.com/css2?family=Lobster+Two:wght@400;700&family=Playfair+Display:wght@400;500;700&display=swap" rel="stylesheet"/>
+  <link rel="stylesheet" href="css/style.css"/>
+</head>
+<body>
+  <header>
+    <div class="container top">
+      <a class="brand" href="index.html">
+        <span class="brand-logo" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M20 9c0-3.3-3.1-6-7-6-3.4 0-6.3 1.9-6.9 4.6C4.1 7.6 3 8.4 3 9.5c0 1 .9 1.9 2 1.9h.3c.6 2.7 3.5 4.6 6.9 4.6 1.6 0 3.1-.4 4.3-1.1l1.8 1.1c.5.3 1.2.1 1.5-.4.3-.5.1-1.2-.4-1.5l-1.2-.7c.9-1.1 1.5-2.5 1.5-4.1Z" fill="%23B399D4"/><circle cx="13.5" cy="6.5" r=".8" fill="#2f2a37"/></svg>
+        </span>
+        <span>S&S Kreates Co.</span>
+      </a>
+      <nav>
+        <a class="nav-btn" href="shop.html">Shop</a>
+        <a class="nav-btn" href="challenges.html">Challenges</a>
+        <a class="nav-btn" href="lookbook.html">Lookbook</a>
+        <a class="nav-btn" href="about.html">About</a>
+        <a class="nav-btn" href="contact.html">Contact</a>
+        <a class="nav-btn" href="account.html" data-login>My Account <span class="cart-badge" aria-label="items in cart">3</span></a>
+      </nav>
+    </div>
+  </header>
+
+  <div class="container hero">
+    <div class="hero-inner">
+      <div class="hero-art" role="img" aria-label="Pastel swirls with butterflies and coins">
+        <div class="float" aria-hidden="true">
+          <span style="left:5%; --speed:11s">🪙</span>
+          <span style="left:18%; --speed:15s">🦋</span>
+          <span style="left:29%; --speed:13s">🪙</span>
+          <span style="left:47%; --speed:12s">🦋</span>
+          <span style="left:63%; --speed:16s">🪙</span>
+          <span style="left:80%; --speed:14s">🦋</span>
+        </div>
+        <div class="hero-copy">
+          <h1>Save Beautifully. Budget, Playfully.</h1>
+          <p class="lede">Introducing the first digital savings challenge scratch‑off cards — designed by Rose with pastel butterflies, coins and a little magic ✨</p>
+          <div class="buttons">
+            <a class="btn primary" href="shop.html">Shop Scratch‑Offs</a>
+            <a class="btn" href="about.html">How it works</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <main class="container">
+    <section aria-labelledby="home-title">
+      <h2 id="home-title">Try the Digital Scratch‑Off (Demo)</h2>
+      <div class="scratch-wrap">
+        <div>
+          <div class="scratch-card" id="demoCard" aria-live="polite">
+            <div class="scratch-art" aria-hidden="true"></div>
+            <div class="scratch-grid"></div>
+          </div>
+          <p class="scratch-notes">Tip: rub across the silver circles to reveal today’s saving amount. Sparkles appear as you scratch. Use Reset to start again.</p>
+          <div class="buttons" style="margin-top:10px">
+            <button class="btn" id="resetDemo">Reset</button>
+            <button class="btn" id="shuffleDemo">Shuffle amounts</button>
+          </div>
+        </div>
+        <div class="card">
+          <h3>What makes these cards magical?</h3>
+          <ul style="margin:0;padding-left:18px">
+            <li>Scratchable <strong>circles</strong> reveal $ amounts you commit to save</li>
+            <li>Each design features <strong>Rose’s art</strong>: butterflies, coins and pastel flourishes</li>
+            <li><strong>No audio</strong> — just subtle sparkles for excitement</li>
+            <li>Progress can be tracked in your account and in printable companions</li>
+          </ul>
+        </div>
+      </div>
+
+      <h2 style="margin-top:26px">Shop by Category</h2>
+      <div class="grid cols-4">
+        <a class="cat" href="shop.html"><span class="emoji">🃏</span> Scratch‑Off Cards</a>
+        <a class="cat" href="challenges.html"><span class="emoji">🏆</span> Weekly Challenges</a>
+        <a class="cat" href="lookbook.html"><span class="emoji">📒</span> Workbooks & Templates</a>
+        <a class="cat" href="tools.html"><span class="emoji">📊</span> Budgeting Tools</a>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container">© <span id="year"></span> S&S Kreates Co. • Budget, Save & Play</div>
+  </footer>
+
+  <dialog id="loginModal" class="modal">
+    <button type="button" id="closeLogin" class="modal-close" aria-label="Close">×</button>
+    <div id="loginView">
+      <h2>Log In</h2>
+      <form class="modal-form">
+        <label>Email
+          <input type="email" required />
+        </label>
+        <label>Password
+          <input type="password" required />
+        </label>
+        <button type="submit" class="btn primary">Log In</button>
+      </form>
+    </div>
+    <div id="signupView" hidden>
+      <h2>Sign Up</h2>
+      <form class="modal-form">
+        <label>Email
+          <input type="email" required />
+        </label>
+        <label>Password
+          <input type="password" required />
+        </label>
+        <button type="submit" class="btn primary">Create Account</button>
+      </form>
+    </div>
+    <button type="button" class="modal-switch" id="switchAuth">Need an account? Sign up</button>
+  </dialog>
+
+  <script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const year = document.getElementById('year');
+    if (year) year.textContent = new Date().getFullYear();
+
+    const modal = document.getElementById('loginModal');
+    const loginLinks = document.querySelectorAll('[data-login]');
+    const closeBtn = document.getElementById('closeLogin');
+    const switchAuth = document.getElementById('switchAuth');
+    const loginView = document.getElementById('loginView');
+    const signupView = document.getElementById('signupView');
+
+    loginLinks.forEach(link => {
+      link.addEventListener('click', e => {
+        e.preventDefault();
+        modal.showModal();
+      });
+    });
+    if (closeBtn) closeBtn.addEventListener('click', () => modal.close());
+    if (switchAuth) {
+      switchAuth.addEventListener('click', () => {
+        const showSignup = signupView.hasAttribute('hidden');
+        signupView.toggleAttribute('hidden');
+        loginView.toggleAttribute('hidden');
+        switchAuth.textContent = showSignup ? 'Have an account? Log in' : 'Need an account? Sign up';
+      });
+    }
+
+    const demoCard = document.getElementById('demoCard');
+    if (demoCard) {
+      const amountsBase = ["$5","$10","$15","$20","$25","$30"];
+      const grid = document.querySelector('.scratch-grid');
+
+      function makeCircle(label){
+        const wrap = document.createElement('div');
+        wrap.className = 'circle';
+        const amt = document.createElement('span');
+        amt.className = 'amt';
+        amt.textContent = label;
+        const c = document.createElement('canvas');
+        c.className = 'silver';
+        wrap.append(amt,c);
+
+        const ctx = c.getContext('2d');
+        function size(){c.width = wrap.clientWidth; c.height = wrap.clientHeight; paint();}
+        function paint(){
+          const g = ctx.createLinearGradient(0,0,c.width,c.height);
+          g.addColorStop(0,'#c9c9c9'); g.addColorStop(.5,'#f2f2f2'); g.addColorStop(1,'#b8b8b8');
+          ctx.fillStyle=g; ctx.fillRect(0,0,c.width,c.height);
+          ctx.globalCompositeOperation='destination-out';
+        }
+        size();
+        const ro = new ResizeObserver(size); ro.observe(wrap);
+
+        let scratching=false;
+        function spark(x,y){
+          const s=document.createElement('span');
+          s.className='spark'; s.style.left=x+'px'; s.style.top=y+'px'; wrap.appendChild(s); setTimeout(()=>s.remove(),650);
+        }
+        function scratch(e){
+          const rect = c.getBoundingClientRect();
+          const x = (e.touches?e.touches[0].clientX:e.clientX) - rect.left;
+          const y = (e.touches?e.touches[0].clientY:e.clientY) - rect.top;
+          ctx.beginPath(); ctx.arc(x,y,18,0,Math.PI*2); ctx.fill(); spark(x,y);
+        }
+        c.addEventListener('pointerdown',()=>{scratching=true});
+        c.addEventListener('pointerup',()=>{scratching=false});
+        c.addEventListener('pointermove',e=>{ if(scratching) scratch(e) });
+        c.addEventListener('touchstart',e=>{scratching=true; scratch(e)});
+        c.addEventListener('touchmove',scratch);
+        c.addEventListener('touchend',()=>{scratching=false});
+        return wrap;
+      }
+
+      function renderGrid(amounts){
+        grid.innerHTML='';
+        amounts.forEach(a=> grid.appendChild(makeCircle(a)) );
+      }
+      function shuffle(arr){return arr.map(v=>({v, r:Math.random()})).sort((a,b)=>a.r-b.r).map(o=>o.v);}
+
+      renderGrid(amountsBase);
+
+      const resetBtn = document.getElementById('resetDemo');
+      const shuffleBtn = document.getElementById('shuffleDemo');
+      if (resetBtn) resetBtn.addEventListener('click',()=>renderGrid(amountsBase));
+      if (shuffleBtn) shuffleBtn.addEventListener('click',()=>renderGrid(shuffle(amountsBase)));
+    }
+  });
+  </script>
+</body>
+</html>

--- a/lookbook.html
+++ b/lookbook.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Lookbook — S&S Kreates Co.</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com"/>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+  <link href="https://fonts.googleapis.com/css2?family=Lobster+Two:wght@400;700&family=Playfair+Display:wght@400;500;700&display=swap" rel="stylesheet"/>
+  <link rel="stylesheet" href="css/style.css"/>
+</head>
+<body>
+  <header>
+    <div class="container top">
+      <a class="brand" href="index.html">
+        <span class="brand-logo" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M20 9c0-3.3-3.1-6-7-6-3.4 0-6.3 1.9-6.9 4.6C4.1 7.6 3 8.4 3 9.5c0 1 .9 1.9 2 1.9h.3c.6 2.7 3.5 4.6 6.9 4.6 1.6 0 3.1-.4 4.3-1.1l1.8 1.1c.5.3 1.2.1 1.5-.4.3-.5.1-1.2-.4-1.5l-1.2-.7c.9-1.1 1.5-2.5 1.5-4.1Z" fill="%23B399D4"/><circle cx="13.5" cy="6.5" r=".8" fill="#2f2a37"/></svg>
+        </span>
+        <span>S&S Kreates Co.</span>
+      </a>
+      <nav>
+        <a class="nav-btn" href="shop.html">Shop</a>
+        <a class="nav-btn" href="challenges.html">Challenges</a>
+        <a class="nav-btn" href="lookbook.html">Lookbook</a>
+        <a class="nav-btn" href="about.html">About</a>
+        <a class="nav-btn" href="contact.html">Contact</a>
+        <a class="nav-btn" href="account.html" data-login>My Account <span class="cart-badge" aria-label="items in cart">3</span></a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="container">
+    <section aria-labelledby="lb-title">
+      <h2 id="lb-title">Lookbook</h2>
+      <div class="grid cols-3">
+        <div class="card"><h3>Piggy & Coins</h3><div style="aspect-ratio:4/3;border-radius:12px;background:url('data:image/svg+xml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' viewBox=\'0 0 400 300\'%3E%3Crect width=\'400\' height=\'300\' fill=\'%23f6f2fe\'/%3E%3Ccircle cx=\'90\' cy=\'80\' r=\'12\' fill=\'%23B399D4\'/%3E%3Ccircle cx=\'120\' cy=\'56\' r=\'10\' fill=\'%2377D4D1\'/%3E%3Ctext x=\'200\' y=\'170\' text-anchor=\'middle\' font-size=\'80\'%3E%F0%9F%90%B7%3C/text%3E%3C/svg%3E') center/cover no-repeat"></div></div>
+        <div class="card"><h3>Butterfly Garden</h3><div style="aspect-ratio:4/3;border-radius:12px;background:url('data:image/svg+xml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' viewBox=\'0 0 400 300\'%3E%3Crect width=\'400\' height=\'300\' fill=\'%23eefaf8\'/%3E%3Ctext x=\'200\' y=\'160\' text-anchor=\'middle\' font-size=\'80\'%3E%F0%9F%A6%8B%3C/text%3E%3C/svg%3E') center/cover no-repeat"></div></div>
+        <div class="card"><h3>Pastel Swirls</h3><div style="aspect-ratio:4/3;border-radius:12px;background:url('data:image/svg+xml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' viewBox=\'0 0 400 300\'%3E%3Cdefs%3E%3ClinearGradient id=\'g\' x1=\'0\' y1=\'0\' x2=\'1\' y2=\'1\'%3E%3Cstop stop-color=\'%23B399D4\' offset=\'0\'/%3E%3Cstop stop-color=\'%2377D4D1\' offset=\'1\'/%3E%3C/linearGradient%3E%3C/defs%3E%3Crect width=\'400\' height=\'300\' fill=\'url(%23g)\' opacity=\'.25'/%3E%3C/svg%3E') center/cover no-repeat"></div></div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container">© <span id="year"></span> S&S Kreates Co. • Budget, Save & Play</div>
+  </footer>
+
+  <dialog id="loginModal" class="modal">
+    <button type="button" id="closeLogin" class="modal-close" aria-label="Close">×</button>
+    <div id="loginView">
+      <h2>Log In</h2>
+      <form class="modal-form">
+        <label>Email
+          <input type="email" required />
+        </label>
+        <label>Password
+          <input type="password" required />
+        </label>
+        <button type="submit" class="btn primary">Log In</button>
+      </form>
+    </div>
+    <div id="signupView" hidden>
+      <h2>Sign Up</h2>
+      <form class="modal-form">
+        <label>Email
+          <input type="email" required />
+        </label>
+        <label>Password
+          <input type="password" required />
+        </label>
+        <button type="submit" class="btn primary">Create Account</button>
+      </form>
+    </div>
+    <button type="button" class="modal-switch" id="switchAuth">Need an account? Sign up</button>
+  </dialog>
+
+  <script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const year = document.getElementById('year');
+    if (year) year.textContent = new Date().getFullYear();
+
+    const modal = document.getElementById('loginModal');
+    const loginLinks = document.querySelectorAll('[data-login]');
+    const closeBtn = document.getElementById('closeLogin');
+    const switchAuth = document.getElementById('switchAuth');
+    const loginView = document.getElementById('loginView');
+    const signupView = document.getElementById('signupView');
+
+    loginLinks.forEach(link => {
+      link.addEventListener('click', e => {
+        e.preventDefault();
+        modal.showModal();
+      });
+    });
+    if (closeBtn) closeBtn.addEventListener('click', () => modal.close());
+    if (switchAuth) {
+      switchAuth.addEventListener('click', () => {
+        const showSignup = signupView.hasAttribute('hidden');
+        signupView.toggleAttribute('hidden');
+        loginView.toggleAttribute('hidden');
+        switchAuth.textContent = showSignup ? 'Have an account? Log in' : 'Need an account? Sign up';
+      });
+    }
+  });
+  </script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "sskreates",
+  "version": "1.0.0",
+  "description": "E-commerce for budgeting tools, professional worksheets/workbooks, digital/physical scratch-off cards.",
+  "main": "index.js",
+  "scripts": {
+    "test": "python -m unittest discover tests"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/shop.html
+++ b/shop.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Shop — S&S Kreates Co.</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com"/>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+  <link href="https://fonts.googleapis.com/css2?family=Lobster+Two:wght@400;700&family=Playfair+Display:wght@400;500;700&display=swap" rel="stylesheet"/>
+  <link rel="stylesheet" href="css/style.css"/>
+</head>
+<body>
+  <header>
+    <div class="container top">
+      <a class="brand" href="index.html">
+        <span class="brand-logo" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M20 9c0-3.3-3.1-6-7-6-3.4 0-6.3 1.9-6.9 4.6C4.1 7.6 3 8.4 3 9.5c0 1 .9 1.9 2 1.9h.3c.6 2.7 3.5 4.6 6.9 4.6 1.6 0 3.1-.4 4.3-1.1l1.8 1.1c.5.3 1.2.1 1.5-.4.3-.5.1-1.2-.4-1.5l-1.2-.7c.9-1.1 1.5-2.5 1.5-4.1Z" fill="%23B399D4"/><circle cx="13.5" cy="6.5" r=".8" fill="#2f2a37"/></svg>
+        </span>
+        <span>S&S Kreates Co.</span>
+      </a>
+      <nav>
+        <a class="nav-btn" href="shop.html">Shop</a>
+        <a class="nav-btn" href="challenges.html">Challenges</a>
+        <a class="nav-btn" href="lookbook.html">Lookbook</a>
+        <a class="nav-btn" href="about.html">About</a>
+        <a class="nav-btn" href="contact.html">Contact</a>
+        <a class="nav-btn" href="account.html" data-login>My Account <span class="cart-badge" aria-label="items in cart">3</span></a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="container">
+    <section aria-labelledby="shop-title">
+      <h2 id="shop-title">Shop Magical Tools</h2>
+      <div class="wc">
+        <p>These blocks render when pasted into a WordPress/WooCommerce page:</p>
+        <p><code>[product_categories columns="4" number="8"]</code></p>
+        <p><code>[products limit="8" orderby="popularity" columns="4" visibility="visible"]</code></p>
+        <p><code>[products limit="8" columns="4" tag="digital-scratch-off"]</code></p>
+      </div>
+      <div class="grid cols-3" style="margin-top:16px">
+        <div class="card"><h3>52‑Week Scratch Challenge</h3><p class="muted">Digital + printable kit</p><strong>$24.99</strong></div>
+        <div class="card"><h3>Floral Pastel Savings Card</h3><p class="muted">12 circles • custom art</p><strong>$14.99</strong></div>
+        <div class="card"><h3>Butterfly Goal Tracker</h3><p class="muted">Printable companion</p><strong>$7.99</strong></div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container">© <span id="year"></span> S&S Kreates Co. • Budget, Save & Play</div>
+  </footer>
+
+  <dialog id="loginModal" class="modal">
+    <button type="button" id="closeLogin" class="modal-close" aria-label="Close">×</button>
+    <div id="loginView">
+      <h2>Log In</h2>
+      <form class="modal-form">
+        <label>Email
+          <input type="email" required />
+        </label>
+        <label>Password
+          <input type="password" required />
+        </label>
+        <button type="submit" class="btn primary">Log In</button>
+      </form>
+    </div>
+    <div id="signupView" hidden>
+      <h2>Sign Up</h2>
+      <form class="modal-form">
+        <label>Email
+          <input type="email" required />
+        </label>
+        <label>Password
+          <input type="password" required />
+        </label>
+        <button type="submit" class="btn primary">Create Account</button>
+      </form>
+    </div>
+    <button type="button" class="modal-switch" id="switchAuth">Need an account? Sign up</button>
+  </dialog>
+
+  <script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const year = document.getElementById('year');
+    if (year) year.textContent = new Date().getFullYear();
+
+    const modal = document.getElementById('loginModal');
+    const loginLinks = document.querySelectorAll('[data-login]');
+    const closeBtn = document.getElementById('closeLogin');
+    const switchAuth = document.getElementById('switchAuth');
+    const loginView = document.getElementById('loginView');
+    const signupView = document.getElementById('signupView');
+
+    loginLinks.forEach(link => {
+      link.addEventListener('click', e => {
+        e.preventDefault();
+        modal.showModal();
+      });
+    });
+    if (closeBtn) closeBtn.addEventListener('click', () => modal.close());
+    if (switchAuth) {
+      switchAuth.addEventListener('click', () => {
+        const showSignup = signupView.hasAttribute('hidden');
+        signupView.toggleAttribute('hidden');
+        loginView.toggleAttribute('hidden');
+        switchAuth.textContent = showSignup ? 'Have an account? Log in' : 'Need an account? Sign up';
+      });
+    }
+  });
+  </script>
+</body>
+</html>

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -1,0 +1,63 @@
+import unittest
+from html.parser import HTMLParser
+
+class PageParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.lang = None
+        self.header = False
+        self.main = False
+        self.footer = False
+        self.titles = []
+        self.login_links = []
+        self.styles = []
+        self.dialog = False
+        self.in_title = False
+    def handle_starttag(self, tag, attrs):
+        attrs = dict(attrs)
+        if tag == 'html':
+            self.lang = attrs.get('lang')
+        if tag == 'header':
+            self.header = True
+        if tag == 'main':
+            self.main = True
+        if tag == 'footer':
+            self.footer = True
+        if tag == 'title':
+            self.in_title = True
+        if tag == 'a' and 'data-login' in attrs:
+            self.login_links.append(attrs.get('href'))
+        if tag == 'link' and attrs.get('rel') == 'stylesheet':
+            self.styles.append(attrs.get('href'))
+        if tag == 'dialog' and attrs.get('id') == 'loginModal':
+            self.dialog = True
+    def handle_endtag(self, tag):
+        if tag == 'title':
+            self.in_title = False
+    def handle_data(self, data):
+        if self.in_title:
+            self.titles.append(data.strip())
+
+PAGES = [
+    'index.html','shop.html','challenges.html','lookbook.html',
+    'about.html','tools.html','contact.html','account.html'
+]
+
+class TestPages(unittest.TestCase):
+    def test_structure(self):
+        for page in PAGES:
+            with self.subTest(page=page):
+                parser = PageParser()
+                with open(page, encoding='utf-8') as f:
+                    parser.feed(f.read())
+                self.assertEqual(parser.lang, 'en')
+                self.assertTrue(parser.header)
+                self.assertTrue(parser.main)
+                self.assertTrue(parser.footer)
+                self.assertTrue(parser.titles)
+                self.assertTrue(parser.login_links)
+                self.assertIn('css/style.css', parser.styles)
+                self.assertTrue(parser.dialog)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools.html
+++ b/tools.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Tools — S&S Kreates Co.</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com"/>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+  <link href="https://fonts.googleapis.com/css2?family=Lobster+Two:wght@400;700&family=Playfair+Display:wght@400;500;700&display=swap" rel="stylesheet"/>
+  <link rel="stylesheet" href="css/style.css"/>
+</head>
+<body>
+  <header>
+    <div class="container top">
+      <a class="brand" href="index.html">
+        <span class="brand-logo" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M20 9c0-3.3-3.1-6-7-6-3.4 0-6.3 1.9-6.9 4.6C4.1 7.6 3 8.4 3 9.5c0 1 .9 1.9 2 1.9h.3c.6 2.7 3.5 4.6 6.9 4.6 1.6 0 3.1-.4 4.3-1.1l1.8 1.1c.5.3 1.2.1 1.5-.4.3-.5.1-1.2-.4-1.5l-1.2-.7c.9-1.1 1.5-2.5 1.5-4.1Z" fill="%23B399D4"/><circle cx="13.5" cy="6.5" r=".8" fill="#2f2a37"/></svg>
+        </span>
+        <span>S&S Kreates Co.</span>
+      </a>
+      <nav>
+        <a class="nav-btn" href="shop.html">Shop</a>
+        <a class="nav-btn" href="challenges.html">Challenges</a>
+        <a class="nav-btn" href="lookbook.html">Lookbook</a>
+        <a class="nav-btn" href="about.html">About</a>
+        <a class="nav-btn" href="contact.html">Contact</a>
+        <a class="nav-btn" href="account.html" data-login>My Account <span class="cart-badge" aria-label="items in cart">3</span></a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="container">
+    <section aria-labelledby="tools-title">
+      <h2 id="tools-title">Tools & Resources</h2>
+      <div class="grid cols-3">
+        <div class="card"><h3>Budget Calculator</h3><p class="muted">Plan monthly targets</p></div>
+        <div class="card"><h3>Printable Trackers</h3><p class="muted">Pair with scratch‑offs</p></div>
+        <div class="card"><h3>Cash‑Stuffing Sheets</h3><p class="muted">Minimal, aesthetic</p></div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container">© <span id="year"></span> S&S Kreates Co. • Budget, Save & Play</div>
+  </footer>
+
+  <dialog id="loginModal" class="modal">
+    <button type="button" id="closeLogin" class="modal-close" aria-label="Close">×</button>
+    <div id="loginView">
+      <h2>Log In</h2>
+      <form class="modal-form">
+        <label>Email
+          <input type="email" required />
+        </label>
+        <label>Password
+          <input type="password" required />
+        </label>
+        <button type="submit" class="btn primary">Log In</button>
+      </form>
+    </div>
+    <div id="signupView" hidden>
+      <h2>Sign Up</h2>
+      <form class="modal-form">
+        <label>Email
+          <input type="email" required />
+        </label>
+        <label>Password
+          <input type="password" required />
+        </label>
+        <button type="submit" class="btn primary">Create Account</button>
+      </form>
+    </div>
+    <button type="button" class="modal-switch" id="switchAuth">Need an account? Sign up</button>
+  </dialog>
+
+  <script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const year = document.getElementById('year');
+    if (year) year.textContent = new Date().getFullYear();
+
+    const modal = document.getElementById('loginModal');
+    const loginLinks = document.querySelectorAll('[data-login]');
+    const closeBtn = document.getElementById('closeLogin');
+    const switchAuth = document.getElementById('switchAuth');
+    const loginView = document.getElementById('loginView');
+    const signupView = document.getElementById('signupView');
+
+    loginLinks.forEach(link => {
+      link.addEventListener('click', e => {
+        e.preventDefault();
+        modal.showModal();
+      });
+    });
+    if (closeBtn) closeBtn.addEventListener('click', () => modal.close());
+    if (switchAuth) {
+      switchAuth.addEventListener('click', () => {
+        const showSignup = signupView.hasAttribute('hidden');
+        signupView.toggleAttribute('hidden');
+        loginView.toggleAttribute('hidden');
+        switchAuth.textContent = showSignup ? 'Have an account? Log in' : 'Need an account? Sign up';
+      });
+    }
+  });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Move all interactive JavaScript inline so each HTML page can be dropped into a WordPress HTML block
- Drop external `main.js` and keep a single shared stylesheet referenced by every page
- Extend tests to verify global style link and presence of login dialog on all pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bde29d07b483259ba4c7ee373a7252